### PR TITLE
TASK: Update neos-ui to version 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "neos/neos": "*",
-        "neos/neos-ui": "^3.8 || ^2.7",
+        "neos/neos-ui": "^4.0 || ^2.7",
         "neos/nodetypes": "*"
     },
     "autoload": {


### PR DESCRIPTION
The neos-ui used the 3.x branch for neos 4.x quite a while but the branch has been deprecated. So if your neos 4.3 for instance uses the latest supported ui version you are not able to install this package.

Therefore this need to be adapted.